### PR TITLE
Fix Package install

### DIFF
--- a/smc-monitoring/requirements.txt
+++ b/smc-monitoring/requirements.txt
@@ -1,3 +1,3 @@
 #file:../#egg=smc-python
-smc-python >= 0.6.0
+fp-NGFW-SMC-python >= 0.7.0
 websocket-client >= 0.48.0


### PR DESCRIPTION
When you install monitoring package, this will install the old SMC-python package and break stuff.