### PR TITLE
fix attribute error for abc in collection on older python 2.7

### DIFF
--- a/smc/base/structs.py
+++ b/smc/base/structs.py
@@ -2,7 +2,19 @@
 Common structures
 """
 import collections
-
+"""
+be more tolerant for abc in older collections / older python 2.7
+"""
+try:
+    collectionsAbc = collections.abc
+except AttributeError:
+    collectionsAbc = collections"""
+be more tolerant for abc in older collections / older python 2.7
+"""
+try:
+    collectionsAbc = collections.abc
+except AttributeError:
+    collectionsAbc = collections
 
 class BaseIterable(object):
     """
@@ -128,7 +140,7 @@ class SerializedIterable(BaseIterable):
         super(SerializedIterable, self).__init__(items)
 
 
-class NestedDict(collections.abc.MutableMapping):
+class NestedDict(collectionsAbc.MutableMapping):
     """
     Generic dict structure that can be used to objectify
     complex json. This dict allows attribute access for data


### PR DESCRIPTION
be more tolerant for abc in older collections / older python 2.7 like CentOS 7