### PR TITLE
fix attribute error for older collections like python 2.7 in CentOS7

### DIFF
--- a/smc/base/structs.py
+++ b/smc/base/structs.py
@@ -8,12 +8,6 @@ be more tolerant for abc in older collections / older python 2.7
 try:
     collectionsAbc = collections.abc
 except AttributeError:
-    collectionsAbc = collections"""
-be more tolerant for abc in older collections / older python 2.7
-"""
-try:
-    collectionsAbc = collections.abc
-except AttributeError:
     collectionsAbc = collections
 
 class BaseIterable(object):

--- a/smc/base/structs.py
+++ b/smc/base/structs.py
@@ -2,7 +2,19 @@
 Common structures
 """
 import collections
-
+"""
+be more tolerant for abc in older collections / older python 2.7
+"""
+try:
+    collectionsAbc = collections.abc
+except AttributeError:
+    collectionsAbc = collections"""
+be more tolerant for abc in older collections / older python 2.7
+"""
+try:
+    collectionsAbc = collections.abc
+except AttributeError:
+    collectionsAbc = collections
 
 class BaseIterable(object):
     """
@@ -128,7 +140,7 @@ class SerializedIterable(BaseIterable):
         super(SerializedIterable, self).__init__(items)
 
 
-class NestedDict(collections.abc.MutableMapping):
+class NestedDict(collectionsAbc.MutableMapping):
     """
     Generic dict structure that can be used to objectify
     complex json. This dict allows attribute access for data


### PR DESCRIPTION
fixes:

Python 2.7.5 (default, Nov 16 2020, 22:23:17)
[GCC 4.8.5 20150623 (Red Hat 4.8.5-44)] on linux2
Type "help", "copyright", "credits" or "license" for more information.
>>> from smc import session
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "/usr/lib/python2.7/site-packages/fp_NGFW_SMC_python-1.0.13-py2.7.egg/smc/__init__.py", line 3, in <module>
    from smc.api.session import SessionManager
  File "/usr/lib/python2.7/site-packages/fp_NGFW_SMC_python-1.0.13-py2.7.egg/smc/api/session.py", line 24, in <module>
    from smc.base.model import ElementFactory
  File "/usr/lib/python2.7/site-packages/fp_NGFW_SMC_python-1.0.13-py2.7.egg/smc/base/model.py", line 56, in <module>
    from smc.base.structs import NestedDict
  File "/usr/lib/python2.7/site-packages/fp_NGFW_SMC_python-1.0.13-py2.7.egg/smc/base/structs.py", line 131, in <module>
    class NestedDict(collections.abc.MutableMapping):
AttributeError: 'module' object has no attribute 'abc'
