### PR TITLE
Fix timestamp on windows

### DIFF
--- a/smc-monitoring/smc_monitoring/models/calendar.py
+++ b/smc-monitoring/smc_monitoring/models/calendar.py
@@ -63,7 +63,7 @@ def subtract_from_now(td):
     Subtract timedelta from current time
     """
     now = datetime.now()
-    return int((now - td).strftime("%s")) * 1000
+    return int((now - td).timestamp() * 1000)
 
 
 def current_millis(): return int(round(time.time() * 1000))


### PR DESCRIPTION
fix : 
return int((now - td).strftime("%s")) * 1000
               ^^^^^^^^^^^^^^^^^^^^^^^^^
ValueError: Invalid format string