### PR TITLE
Reverse 'PEM as string' checks to fix long filename error

### DIFF
--- a/smc/administration/certificates/tls_common.py
+++ b/smc/administration/certificates/tls_common.py
@@ -75,9 +75,10 @@ def load_cert_chain(chain_file):
 
 def certificate_content(certificate):
     """ decode certificate or use it as it is """
-    cert_value = ''
-    with open(certificate, "rb") as file:
-        cert_value = file.read() if not pem_as_string(certificate) else certificate
+    cert_value = certificate
+    if not pem_as_string(certificate):
+        with open(certificate, "rb") as file:
+            cert_value = file.read()
     return cert_value
 
 
@@ -203,8 +204,8 @@ class ImportPrivateKey(object):
             resource="private_key_import",
             headers={"content-type": "multipart/form-data"},
             files={
-                "private_key": open(private_key, "rb")
-                if not pem_as_string(private_key)
-                else private_key
+                "private_key": private_key
+                if pem_as_string(private_key)
+                else open(private_key, "rb")
             },
         )


### PR DESCRIPTION
Only opening the `certificate` or `private_key` strings as a filename + path if it's not a PEM style certificate string prevents "File name too long:" errors for long certificates.

See: https://github.com/Forcepoint/fp-NGFW-SMC-python/issues/79

(This has has only been checked on Python 3 to work locally, more thorough checks should be conducted.)